### PR TITLE
geocode-glib.c: use __UCLIBC__ to check for uClibc features

### DIFF
--- a/geocode-glib/geocode-glib.c
+++ b/geocode-glib/geocode-glib.c
@@ -213,7 +213,7 @@ _geocode_object_get_lang (void)
 	return geocode_object_get_lang_for_locale (setlocale (LC_MESSAGES, NULL));
 }
 
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 static gpointer
 is_number_after_street (gpointer data)
 {
@@ -246,7 +246,7 @@ is_number_after_street (gpointer data)
 gboolean
 _geocode_object_is_number_after_street (void)
 {
-#ifndef __GLIBC__
+#if !defined(__GLIBC__) || defined(__UCLIBC__)
 	return FALSE;
 #else
 	static GOnce once = G_ONCE_INIT;

--- a/geocode-glib/test-gcglib.c
+++ b/geocode-glib/test-gcglib.c
@@ -395,7 +395,7 @@ test_distance (void)
 static void
 test_locale_format (void)
 {
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 	GeocodeForward *object;
 	GError *error = NULL;
 	GList *res;


### PR DESCRIPTION
Commit f0f85d8d introduces **GLIBC** to check for glibc only features.
However this is not sufficient for uClibc because it shares code with
glibc.  To select for features in glibc but not uClibc, we need
defined(**GLIBC**) && !defined(**UCLIBC**).

We note parenthatically that this is not required for musl which avoids
all such ugly marcos.

Signed-off-by: Anthony G. Basile blueness@gentoo.org
