### PR TITLE
meson: don't assume gir can't be cross compiled.

### DIFF
--- a/geocode-glib/meson.build
+++ b/geocode-glib/meson.build
@@ -69,10 +69,9 @@ pkgconf.generate(libraries: libgcglib,
                  ])
 
 gir = find_program('g-ir-scanner', required: false)
-cross_build = meson.is_cross_build()
 enable_gir = get_option('enable-introspection')
 
-if gir.found() and not cross_build and enable_gir
+if gir.found() and enable_gir
   gir_args = [
     '--quiet',
 	'--c-include=geocode-glib/geocode-glib.h'


### PR DESCRIPTION
This is an outdated assumption that caused problems in various
packages like atk, libgxps and libgit2-glib.